### PR TITLE
docs: update DCO guidelines with setup methods

### DIFF
--- a/docs/src/content/docs/guides/contributing/dco.mdx
+++ b/docs/src/content/docs/guides/contributing/dco.mdx
@@ -31,7 +31,7 @@ Signed-off-by: Your Name <your.email@example.com>
 2. Search for: `git.alwaysSignOff`
 3. Enable the checkbox
 
-This automatically adds the sign-off to all your commits. For more information, see the [official VS Code Git documentation](https://code.visualstudio.com/docs/sourcecontrol/overview#_commit-signing).
+This automatically adds the sign-off to all your commits. For more information, see the [official VS Code Git documentation](https://code.visualstudio.com/docs/sourcecontrol/overview).
 
 ### 2. CLI Method
 
@@ -41,11 +41,13 @@ For terminal users, use the `-s` flag when committing:
 git commit -s -m "Your commit message"
 ```
 
-Alternatively, configure Git to automatically add your sign-off for this repository:
+**Optional:** Create a Git alias to make this easier:
 
 ```bash frame="none"
-git config format.signoff true
+git config alias.cs 'commit -s'
 ```
+
+Then you can use `git cs` instead of `git commit -s` for signed commits.
 
 ## DCO Enforcement
 


### PR DESCRIPTION
Revise the DCO documentation to include detailed setup methods for automatic sign-off. Added instructions for configuring sign-off in VS Code and terminal, enhancing clarity for contributors.

Changes:
- Updated section headers for better organization.
- Added IDE setup instructions for VS Code.
- Clarified CLI method for using the `-s` flag and configuring Git.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured DCO signing guide with clearer headings and a two-part workflow
  * Highlighted VS Code IDE setup as the recommended, easiest method
  * Streamlined CLI sign-off instructions and removed manual sign-off examples
  * Clarified DCO enforcement messaging to indicate automated verification and strict blocking for unsigned commits

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->