### PR TITLE
feat(core): SessionManager, StateMachine, and Interaction flow

### DIFF
--- a/engine/crates/core/src/domain/error.rs
+++ b/engine/crates/core/src/domain/error.rs
@@ -1,0 +1,15 @@
+//! Core domain errors.
+
+use crate::domain::session_state::SessionState;
+use thiserror::Error;
+
+/// Errors from session orchestration and state transitions.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum CoreError {
+    /// The requested transition is not allowed from the current state.
+    #[error("invalid session transition from {from:?} to {to:?}")]
+    InvalidTransition {
+        from: SessionState,
+        to: SessionState,
+    },
+}

--- a/engine/crates/core/src/domain/mod.rs
+++ b/engine/crates/core/src/domain/mod.rs
@@ -1,1 +1,11 @@
 //! Core orchestrator domain types (SessionManager, EventBus, etc.).
+
+mod error;
+mod session_manager;
+mod session_state;
+mod state_machine;
+
+pub use error::CoreError;
+pub use session_manager::SessionManager;
+pub use session_state::SessionState;
+pub use state_machine::StateMachine;

--- a/engine/crates/core/src/domain/session_manager.rs
+++ b/engine/crates/core/src/domain/session_manager.rs
@@ -1,0 +1,34 @@
+//! [`SessionManager`] — central orchestration entry point (composition will inject ports later).
+
+use crate::domain::error::CoreError;
+use crate::domain::state_machine::StateMachine;
+use crate::flows::interaction::{apply_interaction_event, InteractionEvent};
+
+/// Coordinates session lifecycle; owns the global [`StateMachine`].
+///
+/// Future: EventBus, full `FlowRunner`, and capability ports attach here per architecture docs.
+#[derive(Debug, Default)]
+pub struct SessionManager {
+    state_machine: StateMachine,
+}
+
+impl SessionManager {
+    pub fn new() -> Self {
+        Self {
+            state_machine: StateMachine::new(),
+        }
+    }
+
+    pub fn state_machine(&self) -> &StateMachine {
+        &self.state_machine
+    }
+
+    pub fn state_machine_mut(&mut self) -> &mut StateMachine {
+        &mut self.state_machine
+    }
+
+    /// Handle a physical / HMI interaction (MVP Interaction flow).
+    pub fn handle_interaction(&mut self, event: InteractionEvent) -> Result<(), CoreError> {
+        apply_interaction_event(&mut self.state_machine, event)
+    }
+}

--- a/engine/crates/core/src/domain/session_state.rs
+++ b/engine/crates/core/src/domain/session_state.rs
@@ -1,0 +1,33 @@
+//! Session lifecycle states for the engine orchestrator.
+//!
+//! Values match the architecture documentation (`architecture/modules/core`).
+
+/// Global session lifecycle for the core orchestrator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SessionState {
+    /// No active user session or capture.
+    Idle,
+    /// Waiting for wake word or listen trigger.
+    Listening,
+    /// Capturing audio/video for a session.
+    Recording,
+    /// Running inference (STT, LLM, vision, etc.).
+    Processing,
+    /// Generating output (e.g. TTS) to the user.
+    Responding,
+    /// Unrecoverable or operator-visible failure; requires explicit recovery.
+    Error,
+}
+
+impl SessionState {
+    /// Returns true if an interrupt should tear down in-flight work and move to a safe state.
+    pub fn is_active(self) -> bool {
+        matches!(
+            self,
+            SessionState::Listening
+                | SessionState::Recording
+                | SessionState::Processing
+                | SessionState::Responding
+        )
+    }
+}

--- a/engine/crates/core/src/domain/state_machine.rs
+++ b/engine/crates/core/src/domain/state_machine.rs
@@ -1,0 +1,128 @@
+//! Global session [`StateMachine`](crate::domain::state_machine::StateMachine).
+//!
+//! Enforces valid transitions and interrupt handling described in the architecture docs.
+
+use crate::domain::error::CoreError;
+use crate::domain::session_state::SessionState;
+
+/// Owns [`SessionState`] and validates transitions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StateMachine {
+    state: SessionState,
+}
+
+impl StateMachine {
+    /// Starts in [`SessionState::Idle`].
+    pub fn new() -> Self {
+        Self {
+            state: SessionState::Idle,
+        }
+    }
+
+    /// Current session state.
+    pub fn state(&self) -> SessionState {
+        self.state
+    }
+
+    /// Move to `to` if allowed; otherwise returns [`CoreError::InvalidTransition`].
+    pub fn transition_to(&mut self, to: SessionState) -> Result<(), CoreError> {
+        if !is_valid_transition(self.state, to) {
+            return Err(CoreError::InvalidTransition {
+                from: self.state,
+                to,
+            });
+        }
+        self.state = to;
+        Ok(())
+    }
+
+    /// Roll back in-flight work to a safe state (Listening preferred; Idle when already Listening).
+    ///
+    /// From active capture/inference/response states, transitions to [`SessionState::Listening`].
+    /// Idempotent when already `Idle`, `Listening`, or `Error`.
+    pub fn interrupt(&mut self) {
+        match self.state {
+            SessionState::Recording | SessionState::Processing | SessionState::Responding => {
+                self.state = SessionState::Listening;
+            }
+            SessionState::Listening => {
+                self.state = SessionState::Idle;
+            }
+            SessionState::Idle | SessionState::Error => {}
+        }
+    }
+}
+
+impl Default for StateMachine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn is_valid_transition(from: SessionState, to: SessionState) -> bool {
+    use SessionState::*;
+    match (from, to) {
+        // Idempotent / no-op
+        (a, b) if a == b => true,
+
+        (Idle, Listening) | (Idle, Error) => true,
+        (Listening, Idle)
+        | (Listening, Recording)
+        | (Listening, Processing)
+        | (Listening, Error) => true,
+        (Recording, Listening)
+        | (Recording, Processing)
+        | (Recording, Idle)
+        | (Recording, Error) => true,
+        (Processing, Responding)
+        | (Processing, Listening)
+        | (Processing, Idle)
+        | (Processing, Error) => true,
+        (Responding, Idle) | (Responding, Listening) | (Responding, Error) => true,
+        (Error, Idle) => true,
+
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idle_to_listening_ok() {
+        let mut sm = StateMachine::new();
+        assert!(sm.transition_to(SessionState::Listening).is_ok());
+        assert_eq!(sm.state(), SessionState::Listening);
+    }
+
+    #[test]
+    fn idle_to_recording_invalid() {
+        let mut sm = StateMachine::new();
+        assert_eq!(
+            sm.transition_to(SessionState::Recording),
+            Err(CoreError::InvalidTransition {
+                from: SessionState::Idle,
+                to: SessionState::Recording,
+            })
+        );
+    }
+
+    #[test]
+    fn interrupt_from_processing_goes_to_listening() {
+        let mut sm = StateMachine::new();
+        sm.transition_to(SessionState::Listening).unwrap();
+        sm.transition_to(SessionState::Recording).unwrap();
+        sm.transition_to(SessionState::Processing).unwrap();
+        sm.interrupt();
+        assert_eq!(sm.state(), SessionState::Listening);
+    }
+
+    #[test]
+    fn interrupt_from_listening_goes_to_idle() {
+        let mut sm = StateMachine::new();
+        sm.transition_to(SessionState::Listening).unwrap();
+        sm.interrupt();
+        assert_eq!(sm.state(), SessionState::Idle);
+    }
+}

--- a/engine/crates/core/src/flows/interaction.rs
+++ b/engine/crates/core/src/flows/interaction.rs
@@ -1,0 +1,84 @@
+//! MVP **Interaction** flow: physical UI events → session actions.
+//!
+//! Maps to [Core: MVP Flows — Interaction](https://docs.aurintex.com/architecture/modules/core/#mvp-flows-flows-module)
+//! (e.g. button short press → start listening). Full `FlowRunner`, Voice, and EventBus are separate work.
+
+use crate::domain::{CoreError, SessionState, StateMachine};
+
+/// Physical / HMI events that the composition root will eventually receive from the peripherals layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InteractionEvent {
+    /// Short press: request listen / wake path — transitions toward [`SessionState::Listening`] when valid.
+    ///
+    /// Typical mapping: idle device → arm listening (wake word, VAD, etc. in later layers).
+    ShortPressStartListen,
+    /// User or system interrupt: tear down in-flight work to a safe session state (see [`StateMachine::interrupt`]).
+    Interrupt,
+}
+
+/// Apply a single interaction event to the global [`StateMachine`].
+pub fn apply_interaction_event(
+    machine: &mut StateMachine,
+    event: InteractionEvent,
+) -> Result<(), CoreError> {
+    match event {
+        InteractionEvent::Interrupt => {
+            machine.interrupt();
+            Ok(())
+        }
+        InteractionEvent::ShortPressStartListen => machine.transition_to(SessionState::Listening),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_press_idle_to_listening() {
+        let mut sm = StateMachine::new();
+        apply_interaction_event(&mut sm, InteractionEvent::ShortPressStartListen).unwrap();
+        assert_eq!(sm.state(), SessionState::Listening);
+    }
+
+    #[test]
+    fn short_press_idempotent_while_listening() {
+        let mut sm = StateMachine::new();
+        apply_interaction_event(&mut sm, InteractionEvent::ShortPressStartListen).unwrap();
+        apply_interaction_event(&mut sm, InteractionEvent::ShortPressStartListen).unwrap();
+        assert_eq!(sm.state(), SessionState::Listening);
+    }
+
+    #[test]
+    fn interrupt_from_processing_via_event() {
+        let mut sm = StateMachine::new();
+        sm.transition_to(SessionState::Listening).unwrap();
+        sm.transition_to(SessionState::Recording).unwrap();
+        sm.transition_to(SessionState::Processing).unwrap();
+        apply_interaction_event(&mut sm, InteractionEvent::Interrupt).unwrap();
+        assert_eq!(sm.state(), SessionState::Listening);
+    }
+
+    #[test]
+    fn short_press_from_error_is_rejected() {
+        let mut sm = StateMachine::new();
+        sm.transition_to(SessionState::Error).unwrap();
+        assert_eq!(
+            apply_interaction_event(&mut sm, InteractionEvent::ShortPressStartListen),
+            Err(CoreError::InvalidTransition {
+                from: SessionState::Error,
+                to: SessionState::Listening,
+            })
+        );
+    }
+
+    #[test]
+    fn session_manager_delegates_handle_interaction() {
+        use crate::domain::SessionManager;
+
+        let mut mgr = SessionManager::new();
+        mgr.handle_interaction(InteractionEvent::ShortPressStartListen)
+            .unwrap();
+        assert_eq!(mgr.state_machine().state(), SessionState::Listening);
+    }
+}

--- a/engine/crates/core/src/flows/mod.rs
+++ b/engine/crates/core/src/flows/mod.rs
@@ -1,1 +1,7 @@
-//! High-level flows and state machines for the engine.
+//! High-level flows and MVP interaction with the session state machine.
+//!
+//! See [`interaction`] for the Interaction flow (UI events → session actions).
+
+pub mod interaction;
+
+pub use interaction::{apply_interaction_event, InteractionEvent};

--- a/engine/crates/core/src/lib.rs
+++ b/engine/crates/core/src/lib.rs
@@ -1,3 +1,16 @@
+//! # pai-core
+//!
+//! Central orchestrator domain for the paiOS engine: [`SessionState`](domain::SessionState),
+//! [`StateMachine`](domain::StateMachine), [`SessionManager`](domain::SessionManager), MVP
+//! [`flows::interaction`](flows), and (later) hexagonal ports.
+//!
+//! **Architecture:** [Core module](https://docs.aurintex.com/architecture/modules/core/) —
+//! SessionManager, state machine, flows, EventBus, and saga rollback are described there; only part
+//! of that surface is implemented so far (session lifecycle + Interaction flow helpers).
+//!
+//! The composition root is [`pai-engine`](https://github.com/aurintex/pai-os/tree/main/engine/pai-engine);
+//! it is the only place that should construct adapters and inject them into core.
+
 pub mod adapters;
 pub mod domain;
 pub mod flows;

--- a/engine/pai-engine/src/main.rs
+++ b/engine/pai-engine/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::{ArgAction, Parser};
+use pai_core::domain::SessionManager;
 use std::path::PathBuf;
 use tracing::{error, info};
 use tracing_subscriber::FmtSubscriber;
@@ -33,8 +34,12 @@ async fn main() -> Result<()> {
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    // 3. Bootstrap engine (placeholder for now)
-    info!("Booting paiOS engine workspace...");
+    // 3. Bootstrap engine — core session orchestration (adapters wire in later)
+    let session = SessionManager::new();
+    info!(
+        "Booting paiOS engine workspace (session state: {:?})...",
+        session.state_machine().state()
+    );
 
     if let Some(path) = args.config {
         info!("Using configuration from: {}", path.display());


### PR DESCRIPTION
## Summary
Implements the foundational session layer for GitHub #62: global `SessionState`, validated `StateMachine` (transitions + interrupt), `SessionManager`, and MVP `flows::interaction` (`ShortPressStartListen`, `Interrupt`). Wires `SessionManager` in `pai-engine` startup and adds crate-level rustdoc.

## Out of scope (follow-up)
- EventBus, FlowRunner, full saga teardown of audio/vision/inference adapters
- Hexagonal `Orchestrator` and port traits in `core::ports`

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (workspace)

Closes #62

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new session transition/interrupt logic that will become central to orchestration; incorrect transition rules could cause unexpected state behavior as more flows integrate.
> 
> **Overview**
> Implements the initial core session-orchestration surface: `SessionState`, a validated `StateMachine` (explicit transition matrix + `interrupt()` rollback), and a `CoreError::InvalidTransition` for rejected transitions.
> 
> Adds an MVP `flows::interaction` mapping physical `InteractionEvent`s (start-listen, interrupt) onto the state machine, and introduces a `SessionManager` façade that owns the machine and delegates interaction handling.
> 
> Updates `pai-engine` startup to construct a `SessionManager` and log the initial session state, and expands `pai-core` crate docs/exports accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1d10aea4cae464f251fe36fc0a22bb5f29d832c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Introduced session lifecycle management with distinct operational states (idle, listening, recording, processing, responding, error)
- Implemented user interaction controls: short-press to start listening and interrupt to stop current operations
- Added session orchestration system to manage state transitions and enforce valid session flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->