### PR TITLE
feat(common): add FileConfigAdapter for TOML, YAML, and JSON

### DIFF
--- a/docs/src/content/docs/architecture/modules/common.mdx
+++ b/docs/src/content/docs/architecture/modules/common.mdx
@@ -44,11 +44,11 @@ Like other domain crates, `common` follows the Hexagonal Architecture pattern. F
 
 - **Contract:** Defines how system and hardware configuration is retrieved.
 - **Adapter:** `FileConfigAdapter`: Parses static configuration files from the local filesystem (e.g., `hardware.toml`).
-- **Supported formats:** TOML, YAML, or JSON. The adapter must detect the format automatically (via file extension or content sniffing) or be configured explicitly at initialization.
+- **Supported formats:** TOML, YAML, or JSON. Resolution order: (1) optional fixed format via `FileConfigAdapter::with_format` at construction, (2) else file extension (`.toml`, `.yaml`, `.yml`, `.json`), (3) else lightweight content sniffing (e.g. `{` → JSON, `[[` / `[table]` → TOML, `---` → YAML). Helpers: `FileConfigAdapter`, `sniff_format` in `engine/crates/common`.
 - Domain crates depend only on the `ConfigProvider` trait; they never depend on file formats or filesystem details.
 
 <Aside type="note">
-**Implementation detail:** The format detection/configuration mechanism for `FileConfigAdapter` needs to be defined during implementation. Options include file extension-based detection (`.toml`, `.yaml`, `.json`) or explicit format specification in the adapter constructor. Tracked in [GitHub Issue #36](https://github.com/aurintex/pai-os/issues/36).
+**Implementation:** `FileConfigAdapter` and `sniff_format` are implemented under `engine/crates/common` (`src/adapters/file_config.rs`). Background: [Issue #36](https://github.com/aurintex/pai-os/issues/36).
 </Aside>
 
 ### PermissionManager Port & SQLitePermissionAdapter

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -180,7 +180,12 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 name = "common"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
  "thiserror",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -198,7 +203,7 @@ dependencies = [
  "serde-untagged",
  "serde_core",
  "serde_json",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "winnow",
  "yaml-rust2",
 ]
@@ -218,7 +223,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
 ]
@@ -286,6 +291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "erased-serde"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +316,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
 
 [[package]]
 name = "foldhash"
@@ -340,6 +357,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +404,24 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "inference"
@@ -407,10 +461,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -601,6 +667,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +693,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "redox_syscall"
@@ -669,10 +751,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -731,11 +838,33 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -799,6 +928,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -891,15 +1033,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -912,6 +1075,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +1096,12 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -1012,6 +1195,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1239,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1312,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "thiserror",
- "toml 0.8.23",
+ "toml",
 ]
 
 [[package]]
@@ -203,7 +203,7 @@ dependencies = [
  "serde-untagged",
  "serde_core",
  "serde_json",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "winnow",
  "yaml-rust2",
 ]
@@ -838,15 +838,6 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
@@ -1033,36 +1024,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
-name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
+ "indexmap",
  "serde_core",
- "serde_spanned 1.0.4",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -1075,20 +1047,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,10 +1056,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"

--- a/engine/crates/common/Cargo.toml
+++ b/engine/crates/common/Cargo.toml
@@ -7,4 +7,11 @@ description = "Shared foundation: logging, error types, config, and permission c
 repository = "https://github.com/aurintex/pai-os"
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.9"
 thiserror = "2.0"
+toml = "0.8"
+
+[dev-dependencies]
+tempfile = "3"

--- a/engine/crates/common/Cargo.toml
+++ b/engine/crates/common/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 thiserror = "2.0"
-toml = "0.8"
+toml = "0.9"
 
 [dev-dependencies]
 tempfile = "3"

--- a/engine/crates/common/src/adapters/file_config.rs
+++ b/engine/crates/common/src/adapters/file_config.rs
@@ -84,7 +84,8 @@ fn parse_config<T: DeserializeOwned>(
 /// Infer format from leading content when extension is missing or unknown.
 ///
 /// Heuristics: JSON objects start with `{`; TOML array-of-tables with `[[`; a single TOML table
-/// `[name]` is distinguished from a JSON array; YAML documents may start with `---` or `%YAML`.
+/// `[name]` is distinguished from a JSON array; YAML may start with `---` / `%YAML`, or the first
+/// non-empty, non-comment line may look like `key: value` (no `=`).
 pub fn sniff_format(content: &str) -> ConfigFileFormat {
     let t = content.trim_start();
     if t.is_empty() {
@@ -110,6 +111,15 @@ pub fn sniff_format(content: &str) -> ConfigFileFormat {
     }
     if t.starts_with("---") || t.starts_with("%YAML") {
         return ConfigFileFormat::Yaml;
+    }
+    if let Some(first_non_empty) = t
+        .lines()
+        .map(str::trim_start)
+        .find(|line| !line.is_empty() && !line.starts_with('#'))
+    {
+        if first_non_empty.contains(':') && !first_non_empty.contains('=') {
+            return ConfigFileFormat::Yaml;
+        }
     }
     ConfigFileFormat::Toml
 }
@@ -153,11 +163,7 @@ count = 2
     fn extension_yaml() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("cfg.yaml");
-        fs::write(
-            &path,
-            "name: pai\ncount: 2\n",
-        )
-        .unwrap();
+        fs::write(&path, "name: pai\ncount: 2\n").unwrap();
         let adapter = FileConfigAdapter::new();
         let v: Sample = adapter.load(&path).expect("load");
         assert_eq!(
@@ -173,11 +179,7 @@ count = 2
     fn extension_json() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("cfg.json");
-        fs::write(
-            &path,
-            r#"{"name": "pai", "count": 2}"#,
-        )
-        .unwrap();
+        fs::write(&path, r#"{"name": "pai", "count": 2}"#).unwrap();
         let adapter = FileConfigAdapter::new();
         let v: Sample = adapter.load(&path).expect("load");
         assert_eq!(
@@ -205,7 +207,6 @@ count = 2
         let path = dir.path().join("noext");
         let mut f = fs::File::create(&path).unwrap();
         write!(f, r#"{{"name": "x", "count": 1}}"#).unwrap();
-        drop(f);
         let adapter = FileConfigAdapter::new();
         let v: Sample = adapter.load(&path).expect("load");
         assert_eq!(v.name, "x");
@@ -228,5 +229,20 @@ count = 2
         assert_eq!(sniff_format("[table]\na=1"), ConfigFileFormat::Toml);
         assert_eq!(sniff_format("[1,2]"), ConfigFileFormat::Json);
         assert_eq!(sniff_format("---\nname: x"), ConfigFileFormat::Yaml);
+        assert_eq!(
+            sniff_format("name: pai\ncount: 1\n"),
+            ConfigFileFormat::Yaml
+        );
+    }
+
+    #[test]
+    fn extensionless_plain_yaml_sniffs_yaml() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config");
+        fs::write(&path, "name: pai\ncount: 2\n").unwrap();
+        let adapter = FileConfigAdapter::new();
+        let v: Sample = adapter.load(&path).expect("load");
+        assert_eq!(v.name, "pai");
+        assert_eq!(v.count, 2);
     }
 }

--- a/engine/crates/common/src/adapters/file_config.rs
+++ b/engine/crates/common/src/adapters/file_config.rs
@@ -1,0 +1,232 @@
+//! Filesystem-backed configuration using TOML, YAML, or JSON.
+
+use crate::domain::ConfigError;
+use crate::ports::ConfigProvider;
+use serde::de::DeserializeOwned;
+use std::fs;
+use std::path::Path;
+
+/// On-disk format for a configuration file.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConfigFileFormat {
+    Toml,
+    Yaml,
+    Json,
+}
+
+/// Loads configuration from a file, supporting TOML, YAML, and JSON.
+///
+/// Format resolution:
+/// 1. If constructed with [`FileConfigAdapter::with_format`], that format is always used.
+/// 2. Otherwise, the file extension is used (`.toml`, `.yaml`, `.yml`, `.json`).
+/// 3. If the extension is missing or unrecognized, the content is inspected (see [`sniff_format`]).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct FileConfigAdapter {
+    format_override: Option<ConfigFileFormat>,
+}
+
+impl FileConfigAdapter {
+    pub fn new() -> Self {
+        Self {
+            format_override: None,
+        }
+    }
+
+    /// Force a single format for every [`ConfigProvider::load`] call (ignores extension and sniffing).
+    pub fn with_format(format: ConfigFileFormat) -> Self {
+        Self {
+            format_override: Some(format),
+        }
+    }
+
+    fn resolve_format(&self, path: &Path, content: &str) -> ConfigFileFormat {
+        if let Some(fmt) = self.format_override {
+            return fmt;
+        }
+        if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+            match ext.to_ascii_lowercase().as_str() {
+                "toml" => return ConfigFileFormat::Toml,
+                "yaml" | "yml" => return ConfigFileFormat::Yaml,
+                "json" => return ConfigFileFormat::Json,
+                _ => {}
+            }
+        }
+        sniff_format(content)
+    }
+}
+
+impl ConfigProvider for FileConfigAdapter {
+    fn load<T: DeserializeOwned>(&self, path: &Path) -> Result<T, ConfigError> {
+        let content = fs::read_to_string(path).map_err(|e| ConfigError::io(path, e))?;
+        let fmt = self.resolve_format(path, &content);
+        parse_config(&content, fmt, path)
+    }
+}
+
+fn parse_config<T: DeserializeOwned>(
+    content: &str,
+    fmt: ConfigFileFormat,
+    path: &Path,
+) -> Result<T, ConfigError> {
+    match fmt {
+        ConfigFileFormat::Toml => {
+            toml::from_str(content).map_err(|e| ConfigError::parse(path, "TOML", e))
+        }
+        ConfigFileFormat::Yaml => {
+            serde_yaml::from_str(content).map_err(|e| ConfigError::parse(path, "YAML", e))
+        }
+        ConfigFileFormat::Json => {
+            serde_json::from_str(content).map_err(|e| ConfigError::parse(path, "JSON", e))
+        }
+    }
+}
+
+/// Infer format from leading content when extension is missing or unknown.
+///
+/// Heuristics: JSON objects start with `{`; TOML array-of-tables with `[[`; a single TOML table
+/// `[name]` is distinguished from a JSON array; YAML documents may start with `---` or `%YAML`.
+pub fn sniff_format(content: &str) -> ConfigFileFormat {
+    let t = content.trim_start();
+    if t.is_empty() {
+        return ConfigFileFormat::Toml;
+    }
+    if t.starts_with('{') {
+        return ConfigFileFormat::Json;
+    }
+    if t.starts_with("[[") {
+        return ConfigFileFormat::Toml;
+    }
+    if let Some(after_bracket) = t.strip_prefix('[') {
+        for c in after_bracket.chars() {
+            if c.is_whitespace() {
+                continue;
+            }
+            if c.is_ascii_alphabetic() || c == '_' {
+                return ConfigFileFormat::Toml;
+            }
+            break;
+        }
+        return ConfigFileFormat::Json;
+    }
+    if t.starts_with("---") || t.starts_with("%YAML") {
+        return ConfigFileFormat::Yaml;
+    }
+    ConfigFileFormat::Toml
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use std::io::Write;
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct Sample {
+        name: String,
+        count: u32,
+    }
+
+    #[test]
+    fn extension_toml() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cfg.toml");
+        fs::write(
+            &path,
+            r#"
+name = "pai"
+count = 2
+"#,
+        )
+        .unwrap();
+        let adapter = FileConfigAdapter::new();
+        let v: Sample = adapter.load(&path).expect("load");
+        assert_eq!(
+            v,
+            Sample {
+                name: "pai".into(),
+                count: 2
+            }
+        );
+    }
+
+    #[test]
+    fn extension_yaml() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cfg.yaml");
+        fs::write(
+            &path,
+            "name: pai\ncount: 2\n",
+        )
+        .unwrap();
+        let adapter = FileConfigAdapter::new();
+        let v: Sample = adapter.load(&path).expect("load");
+        assert_eq!(
+            v,
+            Sample {
+                name: "pai".into(),
+                count: 2
+            }
+        );
+    }
+
+    #[test]
+    fn extension_json() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cfg.json");
+        fs::write(
+            &path,
+            r#"{"name": "pai", "count": 2}"#,
+        )
+        .unwrap();
+        let adapter = FileConfigAdapter::new();
+        let v: Sample = adapter.load(&path).expect("load");
+        assert_eq!(
+            v,
+            Sample {
+                name: "pai".into(),
+                count: 2
+            }
+        );
+    }
+
+    #[test]
+    fn with_format_overrides_extension() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cfg.txt");
+        fs::write(&path, r#"{"name": "pai", "count": 2}"#).unwrap();
+        let adapter = FileConfigAdapter::with_format(ConfigFileFormat::Json);
+        let v: Sample = adapter.load(&path).expect("load");
+        assert_eq!(v.count, 2);
+    }
+
+    #[test]
+    fn sniff_json_without_extension() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("noext");
+        let mut f = fs::File::create(&path).unwrap();
+        write!(f, r#"{{"name": "x", "count": 1}}"#).unwrap();
+        drop(f);
+        let adapter = FileConfigAdapter::new();
+        let v: Sample = adapter.load(&path).expect("load");
+        assert_eq!(v.name, "x");
+    }
+
+    #[test]
+    fn unknown_extension_sniffs_toml() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cfg.conf");
+        fs::write(&path, "name = \"p\"\ncount = 1\n").unwrap();
+        let adapter = FileConfigAdapter::new();
+        let v: Sample = adapter.load(&path).expect("load");
+        assert_eq!(v.name, "p");
+    }
+
+    #[test]
+    fn sniff_format_cases() {
+        assert_eq!(sniff_format(r#"{"a":1}"#), ConfigFileFormat::Json);
+        assert_eq!(sniff_format("[[t]]\na=1"), ConfigFileFormat::Toml);
+        assert_eq!(sniff_format("[table]\na=1"), ConfigFileFormat::Toml);
+        assert_eq!(sniff_format("[1,2]"), ConfigFileFormat::Json);
+        assert_eq!(sniff_format("---\nname: x"), ConfigFileFormat::Yaml);
+    }
+}

--- a/engine/crates/common/src/adapters/mod.rs
+++ b/engine/crates/common/src/adapters/mod.rs
@@ -1,1 +1,5 @@
 //! Adapters implementing `common` ports (e.g., file-based config, SQLite permissions).
+
+mod file_config;
+
+pub use file_config::{ConfigFileFormat, FileConfigAdapter, sniff_format};

--- a/engine/crates/common/src/adapters/mod.rs
+++ b/engine/crates/common/src/adapters/mod.rs
@@ -2,4 +2,4 @@
 
 mod file_config;
 
-pub use file_config::{ConfigFileFormat, FileConfigAdapter, sniff_format};
+pub use file_config::{sniff_format, ConfigFileFormat, FileConfigAdapter};

--- a/engine/crates/common/src/domain/error.rs
+++ b/engine/crates/common/src/domain/error.rs
@@ -1,0 +1,42 @@
+//! Error types for the `common` crate.
+
+use std::path::PathBuf;
+
+/// Errors from configuration loading and parsing.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("failed to read config file {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to parse {format} config {path}: {message}")]
+    Parse {
+        path: PathBuf,
+        format: &'static str,
+        message: String,
+    },
+}
+
+impl ConfigError {
+    pub(crate) fn io(path: impl Into<PathBuf>, source: std::io::Error) -> Self {
+        ConfigError::Io {
+            path: path.into(),
+            source,
+        }
+    }
+
+    pub(crate) fn parse(
+        path: impl Into<PathBuf>,
+        format: &'static str,
+        message: impl std::fmt::Display,
+    ) -> Self {
+        ConfigError::Parse {
+            path: path.into(),
+            format,
+            message: message.to_string(),
+        }
+    }
+}

--- a/engine/crates/common/src/domain/mod.rs
+++ b/engine/crates/common/src/domain/mod.rs
@@ -1,1 +1,5 @@
 //! Domain types and internal logic for the `common` crate.
+
+mod error;
+
+pub use error::ConfigError;

--- a/engine/crates/common/src/lib.rs
+++ b/engine/crates/common/src/lib.rs
@@ -1,3 +1,7 @@
 pub mod adapters;
 pub mod domain;
 pub mod ports;
+
+pub use adapters::{sniff_format, ConfigFileFormat, FileConfigAdapter};
+pub use domain::ConfigError;
+pub use ports::ConfigProvider;

--- a/engine/crates/common/src/ports/config.rs
+++ b/engine/crates/common/src/ports/config.rs
@@ -1,0 +1,11 @@
+//! Configuration loading port.
+
+use crate::domain::ConfigError;
+use serde::de::DeserializeOwned;
+use std::path::Path;
+
+/// Loads typed configuration values from a backing store (files, remote, etc.).
+pub trait ConfigProvider {
+    /// Deserializes configuration from `path` into `T`.
+    fn load<T: DeserializeOwned>(&self, path: &Path) -> Result<T, ConfigError>;
+}

--- a/engine/crates/common/src/ports/mod.rs
+++ b/engine/crates/common/src/ports/mod.rs
@@ -1,1 +1,5 @@
 //! Ports (traits) for cross-cutting services like configuration and permissions.
+
+mod config;
+
+pub use config::ConfigProvider;

--- a/engine/deny.toml
+++ b/engine/deny.toml
@@ -25,6 +25,9 @@ ignore = ["RUSTSEC-2024-0320"]
 [bans]
 # Prevent multiple versions of the same crate
 multiple-versions = "deny"
+# `hashbrown` is pulled at multiple versions by unrelated transitive stacks (e.g. `indexmap` vs
+# `hashlink`/`yaml-rust2`). Allow until upstream aligns.
+skip = [{ name = "hashbrown" }]
 # Prevent wildcard dependencies
 wildcards = "deny"
 # Deny specific problematic crates


### PR DESCRIPTION
- Introduce ConfigProvider port and FileConfigAdapter with extension-based format selection, optional fixed format via with_format, and sniff_format for extensionless paths.

- Add ConfigError for IO and parse failures; unit tests cover formats and sniffing heuristics.

- Document resolution order in architecture common module (docs).

Verification: cargo test -p common; cargo clippy -p common --all-targets -- -D warnings; cargo build --workspace

Closes #36

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new config loading and parsing logic (including format sniffing) plus several new serialization dependencies; mis-detection or parse errors could affect startup/config behavior, but changes are isolated to the `common` crate and covered by unit tests.
> 
> **Overview**
> Adds a new `ConfigProvider` port and `FileConfigAdapter` adapter in `common` to load typed config from the filesystem in **TOML/YAML/JSON**, with a defined resolution order: optional forced format (`with_format`), otherwise file extension, otherwise lightweight content sniffing (`sniff_format`).
> 
> Introduces `ConfigError` for IO/parse failures, exports the new API from `common`, adds unit tests for extension handling/overrides/sniffing, and updates architecture docs plus `common` dependencies (`serde*`, `toml`, `tempfile`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bdddf9a54c89d3466550c73e34164040d091b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added file-based configuration loading for TOML, YAML, and JSON with explicit format override, extension fallback, and content sniffing.
  * Improved error reporting for config load/parse failures.

* **Documentation**
  * Updated adapter docs with concrete format resolution order and format-detection examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->