### PR TITLE
feat(core): EventBus and HardcodedFlowRunner (#85)

### DIFF
--- a/.cursor/rules/definition-of-done.mdc
+++ b/.cursor/rules/definition-of-done.mdc
@@ -13,7 +13,8 @@ Before declaring any task as "finished" or "done", you MUST:
 
 1.  **Read the DoD Section**: Open and review the "Definition of Done" section in `docs/src/content/docs/guides/contributing/standards.mdx`.
 2.  **Verify Every Point**: Go through each requirement (Functional, Quality, Documentation, Compliance) as defined there.
-3.  **Documentation Sync Check**: If the Rust API was touched, ensure `npm run build` was executed in the `docs/` directory.
+3.  **Rust formatting (engine/)**: If any file under `engine/` changed, run `cargo fmt --all -- --check` with working directory `engine/` (same command as CI). Fix with `cargo fmt --all` in `engine/` if needed.
+4.  **Documentation Sync Check**: If the Rust API was touched, ensure `npm run build` was executed in the `docs/` directory.
 
 ## Final Statement Requirement
 In your final response to the user, you MUST explicitly state:

--- a/.cursor/rules/rust-engine-ci.mdc
+++ b/.cursor/rules/rust-engine-ci.mdc
@@ -1,0 +1,17 @@
+---
+description: >-
+  Run the same rustfmt check as CI before finishing Rust work under engine/.
+globs: engine/**/*.rs
+alwaysApply: false
+---
+
+# Rust engine: format check (CI parity)
+
+CI runs `cargo fmt --all -- --check` with working directory `engine/` (see `.github/workflows/ci.yml`).
+
+Before you mark Rust work complete or commit:
+
+1. `cd engine && cargo fmt --all -- --check`
+2. If it fails: `cd engine && cargo fmt --all`, then re-run the check.
+
+Optional: `pre-commit install` uses `.pre-commit-config.yaml` to run this on commit when `engine/**/*.rs` changes.

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@ node_modules/
 
 # Editor directories and files
 .idea
-.vscode
+# Track shared editor defaults; keep other .vscode/* local
+.vscode/*
+!.vscode/settings.json
 *.suo
 *.ntvs*
 *.njsproj

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# Optional: install with `pip install pre-commit && pre-commit install`
+# Mirrors the "Format check" step in .github/workflows/ci.yml (working-directory: engine).
+
+repos:
+  - repo: local
+    hooks:
+      - id: rustfmt-check-engine
+        name: cargo fmt --check (engine)
+        language: system
+        entry: bash -c 'cd engine && cargo fmt --all -- --check'
+        pass_filenames: false
+        files: ^engine/.*\.rs$

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer",
+    "editor.formatOnSave": true
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Before writing code, **always** check these files for the latest standards:
 - **GitHub issues**: When creating issues (e.g. via MCP or CLI), use **Conventional Commits** for the title: `type(scope): short description` (e.g. `feat(common): add config format detection`). See [Workflow](docs/src/content/docs/guides/contributing/workflow.mdx) for types, scope, and branch naming.
 - **Documentation**: When editing docs, link to the [Glossary](docs/src/content/docs/glossary.mdx) for terms that have an entry (e.g. IPC, gRPC, HITL, UDS). Use `[Term](/glossary/#letter)`.
 - **Rust code**: When writing or reviewing Rust in `engine/`, follow [Rust Style and Best Practices](docs/src/content/docs/guides/contributing/rust-style.mdx) (stack vs heap, generics vs `Box<dyn Trait>`, formatting).
+- **Rust formatting (CI parity)**: Before you commit or open a PR for Rust changes, run the same check as CI from the repo root: `cd engine && cargo fmt --all -- --check`. If it fails, run `cargo fmt --all` in `engine/` and re-check. Optional: install [pre-commit](https://pre-commit.com/) and run `pre-commit install` once so commits are blocked locally when fmt would fail (see `.pre-commit-config.yaml`). With the repo `.vscode/settings.json`, Rust files format on save when using rust-analyzer in Cursor/VS Code.
 
 ## 4. Architecture Summary
 - **Engine**: Rust daemon (`engine/`) running distinct threads for inference (NPU/CPU/GPU).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,12 @@ For complete contribution guidelines, including development setup, code style, C
 
 **Quick note:** First-time contributors need to sign our CLA (Contributor License Agreement). The CLAassistant bot will guide you through the process on your first Pull Request.
 
+## Local checks (Rust)
+
+CI runs `cargo fmt --all -- --check` inside `engine/`. Before pushing Rust changes, run the same command locally (or run `cargo fmt --all` in `engine/` to fix formatting).
+
+Optional: install [pre-commit](https://pre-commit.com/) and run `pre-commit install` in the repo root to run that fmt check automatically when you commit (see `.pre-commit-config.yaml`). Using Cursor/VS Code with rust-analyzer, the committed `.vscode/settings.json` enables format on save for Rust files.
+
 ## Getting Help
 
 If you have questions, found a bug, or need clarification, please reach out:

--- a/docs/src/content/docs/guides/contributing/standards.mdx
+++ b/docs/src/content/docs/guides/contributing/standards.mdx
@@ -51,6 +51,7 @@ All changes must meet these requirements before they can be merged:
 ### 1. Correctness & Quality
 - Code builds without errors (`cargo build`).
 - All tests pass (`cargo test`).
+- Rust code is rustfmt-clean: from the `engine/` directory, `cargo fmt --all -- --check` passes (same as CI; fix with `cargo fmt --all`).
 - No clippy warnings.
 - Solution follows KISS and Hexagonal Architecture principles.
 

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
  "common",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -490,6 +490,7 @@ version = "0.1.0"
 dependencies = [
  "common",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/engine/crates/core/Cargo.toml
+++ b/engine/crates/core/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/aurintex/pai-os"
 [dependencies]
 common = { path = "../common", version = "0.1.0" }
 thiserror = "2.0"
+tokio = { version = "1.50", features = ["sync", "rt", "macros"] }
 
 [features]
 default = []

--- a/engine/crates/core/Cargo.toml
+++ b/engine/crates/core/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/aurintex/pai-os"
 common = { path = "../common", version = "0.1.0" }
 thiserror = "2.0"
 tokio = { version = "1.50", features = ["sync", "rt", "macros"] }
+tracing = "0.1"
 
 [features]
 default = []

--- a/engine/crates/core/src/adapters/hardcoded_flow_runner.rs
+++ b/engine/crates/core/src/adapters/hardcoded_flow_runner.rs
@@ -73,9 +73,7 @@ mod tests {
         let (bus, _rx) = EventBus::channel(8);
         let runner = HardcodedFlowRunner::new(Arc::new(EchoInference), bus);
         let ctx = SessionContext::new(SessionState::Listening, "hi");
-        let out = runner
-            .execute(FlowType::InferenceEcho, &ctx)
-            .unwrap();
+        let out = runner.execute(FlowType::InferenceEcho, &ctx).unwrap();
         assert_eq!(out.response, "echo:hi");
     }
 }

--- a/engine/crates/core/src/adapters/hardcoded_flow_runner.rs
+++ b/engine/crates/core/src/adapters/hardcoded_flow_runner.rs
@@ -3,6 +3,7 @@
 use crate::domain::{DomainEvent, EventBus};
 use crate::ports::{FlowError, FlowResult, FlowRunner, FlowType, InferencePort, SessionContext};
 use std::sync::Arc;
+use tokio::sync::mpsc::error::TrySendError;
 
 /// Built-in flows only; user-defined scripting is out of scope (see issue #38).
 pub struct HardcodedFlowRunner {
@@ -19,9 +20,10 @@ impl HardcodedFlowRunner {
     }
 
     fn publish(&self, event: DomainEvent) -> Result<(), FlowError> {
-        self.event_bus
-            .try_publish(event)
-            .map_err(|_| FlowError::EventBusFull)
+        self.event_bus.try_publish(event).map_err(|e| match e {
+            TrySendError::Full(_) => FlowError::EventBusFull,
+            TrySendError::Closed(_) => FlowError::EventBusClosed,
+        })
     }
 }
 
@@ -68,12 +70,21 @@ mod tests {
         }
     }
 
-    #[test]
-    fn inference_echo_end_to_end() {
-        let (bus, _rx) = EventBus::channel(8);
+    #[tokio::test]
+    async fn inference_echo_end_to_end() {
+        let (bus, mut rx) = EventBus::channel(8);
         let runner = HardcodedFlowRunner::new(Arc::new(EchoInference), bus);
         let ctx = SessionContext::new(SessionState::Listening, "hi");
         let out = runner.execute(FlowType::InferenceEcho, &ctx).unwrap();
         assert_eq!(out.response, "echo:hi");
+
+        match rx.recv().await {
+            Some(DomainEvent::InferenceRequested { prompt }) => assert_eq!(prompt, "hi"),
+            other => panic!("expected InferenceRequested, got {other:?}"),
+        }
+        match rx.recv().await {
+            Some(DomainEvent::InferenceCompleted { response }) => assert_eq!(response, "echo:hi"),
+            other => panic!("expected InferenceCompleted, got {other:?}"),
+        }
     }
 }

--- a/engine/crates/core/src/adapters/hardcoded_flow_runner.rs
+++ b/engine/crates/core/src/adapters/hardcoded_flow_runner.rs
@@ -1,0 +1,81 @@
+//! MVP [`FlowRunner`](crate::ports::FlowRunner) — static request → inference → response.
+
+use crate::domain::{DomainEvent, EventBus};
+use crate::ports::{FlowError, FlowResult, FlowRunner, FlowType, InferencePort, SessionContext};
+use std::sync::Arc;
+
+/// Built-in flows only; user-defined scripting is out of scope (see issue #38).
+pub struct HardcodedFlowRunner {
+    inference: Arc<dyn InferencePort>,
+    event_bus: EventBus,
+}
+
+impl HardcodedFlowRunner {
+    pub fn new(inference: Arc<dyn InferencePort>, event_bus: EventBus) -> Self {
+        Self {
+            inference,
+            event_bus,
+        }
+    }
+
+    fn publish(&self, event: DomainEvent) -> Result<(), FlowError> {
+        self.event_bus
+            .try_publish(event)
+            .map_err(|_| FlowError::EventBusFull)
+    }
+}
+
+impl FlowRunner for HardcodedFlowRunner {
+    fn execute(
+        &self,
+        flow_type: FlowType,
+        context: &SessionContext,
+    ) -> Result<FlowResult, FlowError> {
+        match flow_type {
+            FlowType::InferenceEcho => {
+                if context.prompt.trim().is_empty() {
+                    return Err(FlowError::EmptyPrompt);
+                }
+
+                self.publish(DomainEvent::InferenceRequested {
+                    prompt: context.prompt.clone(),
+                })?;
+
+                let response = self.inference.complete(&context.prompt)?;
+
+                self.publish(DomainEvent::InferenceCompleted {
+                    response: response.clone(),
+                })?;
+
+                Ok(FlowResult { response })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::SessionState;
+    use crate::ports::InferenceError;
+
+    #[derive(Debug)]
+    struct EchoInference;
+
+    impl InferencePort for EchoInference {
+        fn complete(&self, prompt: &str) -> Result<String, InferenceError> {
+            Ok(format!("echo:{prompt}"))
+        }
+    }
+
+    #[test]
+    fn inference_echo_end_to_end() {
+        let (bus, _rx) = EventBus::channel(8);
+        let runner = HardcodedFlowRunner::new(Arc::new(EchoInference), bus);
+        let ctx = SessionContext::new(SessionState::Listening, "hi");
+        let out = runner
+            .execute(FlowType::InferenceEcho, &ctx)
+            .unwrap();
+        assert_eq!(out.response, "echo:hi");
+    }
+}

--- a/engine/crates/core/src/adapters/mod.rs
+++ b/engine/crates/core/src/adapters/mod.rs
@@ -1,1 +1,5 @@
-//! Core driving adapters such as system monitoring.
+//! Core driving adapters such as system monitoring and the MVP flow runner.
+
+mod hardcoded_flow_runner;
+
+pub use hardcoded_flow_runner::HardcodedFlowRunner;

--- a/engine/crates/core/src/domain/event_bus.rs
+++ b/engine/crates/core/src/domain/event_bus.rs
@@ -2,6 +2,7 @@
 
 use crate::domain::events::DomainEvent;
 use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TrySendError;
 
 /// Single-consumer bounded channel for [`DomainEvent`] delivery.
 ///
@@ -24,15 +25,37 @@ impl EventBus {
         self.sender.clone()
     }
 
-    /// Non-blocking publish; returns the event back if the buffer is full.
-    pub fn try_publish(&self, event: DomainEvent) -> Result<(), DomainEvent> {
-        self.sender.try_send(event).map_err(|e| e.into_inner())
+    /// Non-blocking publish. On failure, use [`TrySendError::into_inner`] to recover the event.
+    pub fn try_publish(&self, event: DomainEvent) -> Result<(), TrySendError<DomainEvent>> {
+        self.sender.try_send(event)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::sync::mpsc::error::TrySendError;
+
+    #[tokio::test]
+    async fn try_publish_returns_full_when_buffer_saturated() {
+        let (bus, mut rx) = EventBus::channel(1);
+        bus.try_publish(DomainEvent::InferenceRequested {
+            prompt: "first".into(),
+        })
+        .unwrap();
+
+        let ev = DomainEvent::InferenceRequested {
+            prompt: "second".into(),
+        };
+        let err = bus.try_publish(ev.clone()).unwrap_err();
+        let got = match err {
+            TrySendError::Full(e) => e,
+            other => panic!("expected Full, got {other:?}"),
+        };
+        assert_eq!(got, ev);
+
+        rx.recv().await;
+    }
 
     #[tokio::test]
     async fn send_and_receive_round_trip() {

--- a/engine/crates/core/src/domain/event_bus.rs
+++ b/engine/crates/core/src/domain/event_bus.rs
@@ -1,0 +1,66 @@
+//! Bounded in-process event bus using [`tokio::sync::mpsc`].
+
+use crate::domain::events::DomainEvent;
+use tokio::sync::mpsc;
+
+/// Single-consumer bounded channel for [`DomainEvent`] delivery.
+///
+/// Producers clone [`EventBus::sender`]. Exactly one task should consume the
+/// [`mpsc::Receiver`] returned from [`EventBus::channel`].
+#[derive(Clone, Debug)]
+pub struct EventBus {
+    sender: mpsc::Sender<DomainEvent>,
+}
+
+impl EventBus {
+    /// Creates a bus and the sole receiver. `capacity` is the mpsc queue bound.
+    pub fn channel(capacity: usize) -> (Self, mpsc::Receiver<DomainEvent>) {
+        let (tx, rx) = mpsc::channel(capacity);
+        (Self { sender: tx }, rx)
+    }
+
+    /// Cloneable handle for publishers (fan-in to the single consumer).
+    pub fn sender(&self) -> mpsc::Sender<DomainEvent> {
+        self.sender.clone()
+    }
+
+    /// Non-blocking publish; returns the event back if the buffer is full.
+    pub fn try_publish(&self, event: DomainEvent) -> Result<(), DomainEvent> {
+        self.sender.try_send(event).map_err(|e| e.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn send_and_receive_round_trip() {
+        let (bus, mut rx) = EventBus::channel(4);
+        let prompt = "hello";
+        bus.try_publish(DomainEvent::InferenceRequested {
+            prompt: prompt.into(),
+        })
+        .unwrap();
+
+        match rx.recv().await {
+            Some(DomainEvent::InferenceRequested { prompt: p }) => assert_eq!(p, prompt),
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn sender_clone_delivers_to_same_receiver() {
+        let (bus, mut rx) = EventBus::channel(2);
+        let s2 = bus.sender();
+        s2.try_send(DomainEvent::InferenceCompleted {
+            response: "ok".into(),
+        })
+        .unwrap();
+
+        match rx.recv().await {
+            Some(DomainEvent::InferenceCompleted { response }) => assert_eq!(response, "ok"),
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+}

--- a/engine/crates/core/src/domain/events.rs
+++ b/engine/crates/core/src/domain/events.rs
@@ -1,0 +1,10 @@
+//! Domain events exchanged on the [`crate::domain::EventBus`].
+
+/// Application-level events for orchestration and telemetry (in-process only).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DomainEvent {
+    /// An inference request entered the static flow.
+    InferenceRequested { prompt: String },
+    /// Inference produced a text response.
+    InferenceCompleted { response: String },
+}

--- a/engine/crates/core/src/domain/mod.rs
+++ b/engine/crates/core/src/domain/mod.rs
@@ -1,11 +1,18 @@
 //! Core orchestrator domain types (SessionManager, EventBus, etc.).
 
 mod error;
+mod event_bus;
+mod events;
 mod session_manager;
 mod session_state;
 mod state_machine;
 
 pub use error::CoreError;
+pub use event_bus::EventBus;
+pub use events::DomainEvent;
 pub use session_manager::SessionManager;
 pub use session_state::SessionState;
 pub use state_machine::StateMachine;
+
+#[cfg(test)]
+pub(crate) use session_manager::session_manager_for_interaction_tests;

--- a/engine/crates/core/src/domain/session_manager.rs
+++ b/engine/crates/core/src/domain/session_manager.rs
@@ -4,7 +4,7 @@ use crate::domain::error::CoreError;
 use crate::domain::state_machine::StateMachine;
 use crate::domain::{EventBus, SessionState};
 use crate::flows::interaction::{apply_interaction_event, InteractionEvent};
-use crate::ports::{FlowRunner, FlowType, SessionContext, FlowError};
+use crate::ports::{FlowError, FlowRunner, FlowType, SessionContext};
 use std::sync::Arc;
 
 /// Coordinates session lifecycle; owns the global [`StateMachine`] and delegates flows to [`FlowRunner`].
@@ -134,5 +134,4 @@ mod tests {
             crate::domain::DomainEvent::InferenceCompleted { .. }
         ));
     }
-
 }

--- a/engine/crates/core/src/domain/session_manager.rs
+++ b/engine/crates/core/src/domain/session_manager.rs
@@ -6,6 +6,7 @@ use crate::domain::{EventBus, SessionState};
 use crate::flows::interaction::{apply_interaction_event, InteractionEvent};
 use crate::ports::{FlowError, FlowRunner, FlowType, SessionContext};
 use std::sync::Arc;
+use tracing::warn;
 
 /// Coordinates session lifecycle; owns the global [`StateMachine`] and delegates flows to [`FlowRunner`].
 pub struct SessionManager {
@@ -66,7 +67,13 @@ impl SessionManager {
                 Ok(flow.response)
             }
             Err(e) => {
-                let _ = self.state_machine.transition_to(SessionState::Error);
+                if let Err(transition_err) = self.state_machine.transition_to(SessionState::Error) {
+                    warn!(
+                        flow_error = ?e,
+                        transition_error = ?transition_err,
+                        "failed to transition to Error state after flow failure"
+                    );
+                }
                 Err(e)
             }
         }

--- a/engine/crates/core/src/domain/session_manager.rs
+++ b/engine/crates/core/src/domain/session_manager.rs
@@ -1,21 +1,25 @@
-//! [`SessionManager`] — central orchestration entry point (composition will inject ports later).
+//! [`SessionManager`] — central orchestration entry point (composition injects ports).
 
 use crate::domain::error::CoreError;
 use crate::domain::state_machine::StateMachine;
+use crate::domain::{EventBus, SessionState};
 use crate::flows::interaction::{apply_interaction_event, InteractionEvent};
+use crate::ports::{FlowRunner, FlowType, SessionContext, FlowError};
+use std::sync::Arc;
 
-/// Coordinates session lifecycle; owns the global [`StateMachine`].
-///
-/// Future: EventBus, full `FlowRunner`, and capability ports attach here per architecture docs.
-#[derive(Debug, Default)]
+/// Coordinates session lifecycle; owns the global [`StateMachine`] and delegates flows to [`FlowRunner`].
 pub struct SessionManager {
     state_machine: StateMachine,
+    flow_runner: Arc<dyn FlowRunner>,
+    event_bus: EventBus,
 }
 
 impl SessionManager {
-    pub fn new() -> Self {
+    pub fn new(flow_runner: Arc<dyn FlowRunner>, event_bus: EventBus) -> Self {
         Self {
             state_machine: StateMachine::new(),
+            flow_runner,
+            event_bus,
         }
     }
 
@@ -27,8 +31,108 @@ impl SessionManager {
         &mut self.state_machine
     }
 
+    pub fn event_bus(&self) -> &EventBus {
+        &self.event_bus
+    }
+
+    pub fn flow_runner(&self) -> &Arc<dyn FlowRunner> {
+        &self.flow_runner
+    }
+
     /// Handle a physical / HMI interaction (MVP Interaction flow).
     pub fn handle_interaction(&mut self, event: InteractionEvent) -> Result<(), CoreError> {
         apply_interaction_event(&mut self.state_machine, event)
     }
+
+    /// Run the static inference echo flow: prompt → inference → response, with state transitions.
+    pub fn handle_flow_request(&mut self, prompt: &str) -> Result<String, FlowError> {
+        match self.state_machine.state() {
+            SessionState::Idle => {
+                self.state_machine.transition_to(SessionState::Listening)?;
+            }
+            SessionState::Listening => {}
+            other => return Err(FlowError::SessionNotReady(other)),
+        }
+
+        self.state_machine.transition_to(SessionState::Processing)?;
+
+        let ctx = SessionContext::new(self.state_machine.state(), prompt.to_string());
+        let result = self.flow_runner.execute(FlowType::InferenceEcho, &ctx);
+
+        match result {
+            Ok(flow) => {
+                self.state_machine.transition_to(SessionState::Responding)?;
+                self.state_machine.transition_to(SessionState::Listening)?;
+                Ok(flow.response)
+            }
+            Err(e) => {
+                let _ = self.state_machine.transition_to(SessionState::Error);
+                Err(e)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn session_manager_for_interaction_tests() -> SessionManager {
+    use crate::adapters::HardcodedFlowRunner;
+    use crate::ports::{InferenceError, InferencePort};
+
+    #[derive(Debug)]
+    struct StubInference;
+
+    impl InferencePort for StubInference {
+        fn complete(&self, _prompt: &str) -> Result<String, InferenceError> {
+            Ok(String::new())
+        }
+    }
+
+    let (event_bus, _rx) = EventBus::channel(8);
+    let runner = Arc::new(HardcodedFlowRunner::new(
+        Arc::new(StubInference),
+        event_bus.clone(),
+    ));
+    SessionManager::new(runner, event_bus)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::HardcodedFlowRunner;
+    use crate::domain::SessionState;
+    use crate::ports::{InferenceError, InferencePort};
+
+    #[derive(Debug)]
+    struct EchoInference;
+
+    impl InferencePort for EchoInference {
+        fn complete(&self, prompt: &str) -> Result<String, InferenceError> {
+            Ok(format!("echo:{prompt}"))
+        }
+    }
+
+    #[test]
+    fn handle_flow_request_happy_path() {
+        let (bus, mut rx) = EventBus::channel(8);
+        let runner = Arc::new(HardcodedFlowRunner::new(
+            Arc::new(EchoInference),
+            bus.clone(),
+        ));
+        let mut mgr = SessionManager::new(runner, bus);
+        let out = mgr.handle_flow_request("hello").unwrap();
+        assert_eq!(out, "echo:hello");
+        assert_eq!(mgr.state_machine().state(), SessionState::Listening);
+
+        let e1 = rx.blocking_recv().expect("event 1");
+        let e2 = rx.blocking_recv().expect("event 2");
+        assert!(matches!(
+            e1,
+            crate::domain::DomainEvent::InferenceRequested { .. }
+        ));
+        assert!(matches!(
+            e2,
+            crate::domain::DomainEvent::InferenceCompleted { .. }
+        ));
+    }
+
 }

--- a/engine/crates/core/src/flows/interaction.rs
+++ b/engine/crates/core/src/flows/interaction.rs
@@ -74,9 +74,9 @@ mod tests {
 
     #[test]
     fn session_manager_delegates_handle_interaction() {
-        use crate::domain::SessionManager;
+        use crate::domain::session_manager_for_interaction_tests;
 
-        let mut mgr = SessionManager::new();
+        let mut mgr = session_manager_for_interaction_tests();
         mgr.handle_interaction(InteractionEvent::ShortPressStartListen)
             .unwrap();
         assert_eq!(mgr.state_machine().state(), SessionState::Listening);

--- a/engine/crates/core/src/lib.rs
+++ b/engine/crates/core/src/lib.rs
@@ -2,11 +2,12 @@
 //!
 //! Central orchestrator domain for the paiOS engine: [`SessionState`](domain::SessionState),
 //! [`StateMachine`](domain::StateMachine), [`SessionManager`](domain::SessionManager), MVP
-//! [`flows::interaction`](flows), and (later) hexagonal ports.
+//! [`flows::interaction`](flows), [`EventBus`](domain::EventBus), [`FlowRunner`](ports::FlowRunner),
+//! and [`HardcodedFlowRunner`](adapters::HardcodedFlowRunner).
 //!
 //! **Architecture:** [Core module](https://docs.aurintex.com/architecture/modules/core/) —
-//! SessionManager, state machine, flows, EventBus, and saga rollback are described there; only part
-//! of that surface is implemented so far (session lifecycle + Interaction flow helpers).
+//! SessionManager, state machine, flows, EventBus, and saga rollback are described there; the MVP
+//! static inference flow and bounded event bus are wired; saga rollback is still deferred.
 //!
 //! The composition root is [`pai-engine`](https://github.com/aurintex/pai-os/tree/main/engine/pai-engine);
 //! it is the only place that should construct adapters and inject them into core.

--- a/engine/crates/core/src/ports/flow_runner.rs
+++ b/engine/crates/core/src/ports/flow_runner.rs
@@ -44,6 +44,8 @@ pub enum FlowError {
     Inference(#[from] InferenceError),
     #[error("event bus is full; could not publish domain event")]
     EventBusFull,
+    #[error("event bus is closed (no receiver); could not publish domain event")]
+    EventBusClosed,
     #[error("inference prompt was empty")]
     EmptyPrompt,
     #[error("session state does not allow this flow (state={0:?})")]

--- a/engine/crates/core/src/ports/flow_runner.rs
+++ b/engine/crates/core/src/ports/flow_runner.rs
@@ -1,0 +1,62 @@
+//! [`FlowRunner`] port and flow metadata (see architecture docs: MVP static flows).
+
+use crate::domain::{CoreError, SessionState};
+use crate::ports::inference::InferenceError;
+use thiserror::Error;
+
+/// Static MVP flow kinds; extend as more hardcoded flows land.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FlowType {
+    /// Minimal path: prompt → inference → text response.
+    InferenceEcho,
+}
+
+/// Per-invocation inputs for flow execution (session-scoped).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionContext {
+    /// Snapshot of orchestrator state for the session.
+    pub session_state: SessionState,
+    /// Prompt text for inference-backed flows.
+    pub prompt: String,
+}
+
+impl SessionContext {
+    pub fn new(session_state: SessionState, prompt: impl Into<String>) -> Self {
+        Self {
+            session_state,
+            prompt: prompt.into(),
+        }
+    }
+}
+
+/// Outcome of a completed flow step (MVP: single text result).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlowResult {
+    pub response: String,
+}
+
+/// Errors while executing a flow.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum FlowError {
+    #[error("flow type {0:?} is not supported by this runner")]
+    UnsupportedFlowType(FlowType),
+    #[error("inference error: {0}")]
+    Inference(#[from] InferenceError),
+    #[error("event bus is full; could not publish domain event")]
+    EventBusFull,
+    #[error("inference prompt was empty")]
+    EmptyPrompt,
+    #[error("session state does not allow this flow (state={0:?})")]
+    SessionNotReady(SessionState),
+    #[error(transparent)]
+    State(#[from] CoreError),
+}
+
+/// Executes built-in flows behind a stable interface (MVP: [`crate::adapters::HardcodedFlowRunner`]).
+pub trait FlowRunner: Send + Sync {
+    fn execute(
+        &self,
+        flow_type: FlowType,
+        context: &SessionContext,
+    ) -> Result<FlowResult, FlowError>;
+}

--- a/engine/crates/core/src/ports/inference.rs
+++ b/engine/crates/core/src/ports/inference.rs
@@ -1,0 +1,17 @@
+//! Inference boundary for the core orchestrator (implemented by inference adapters).
+
+use thiserror::Error;
+
+/// Errors from an [`InferencePort`] implementation.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum InferenceError {
+    /// Backend failed to produce a completion.
+    #[error("inference failed: {0}")]
+    Failed(String),
+}
+
+/// Drives text completions (LLM / edge inference). Core depends on this port, not on concrete crates.
+pub trait InferencePort: Send + Sync {
+    /// Run a single prompt/turn and return model text.
+    fn complete(&self, prompt: &str) -> Result<String, InferenceError>;
+}

--- a/engine/crates/core/src/ports/mod.rs
+++ b/engine/crates/core/src/ports/mod.rs
@@ -1,1 +1,7 @@
 //! Ports (traits) defined and consumed by the core orchestrator.
+
+mod flow_runner;
+mod inference;
+
+pub use flow_runner::{FlowError, FlowResult, FlowRunner, FlowType, SessionContext};
+pub use inference::{InferenceError, InferencePort};

--- a/engine/pai-engine/src/main.rs
+++ b/engine/pai-engine/src/main.rs
@@ -5,7 +5,7 @@ use pai_core::domain::{EventBus, SessionManager};
 use pai_core::ports::{InferenceError, InferencePort};
 use std::path::PathBuf;
 use std::sync::Arc;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 use tracing_subscriber::FmtSubscriber;
 
 /// Command line arguments for the paiOS engine.
@@ -47,12 +47,21 @@ async fn main() -> Result<()> {
         }
     }
 
-    let (event_bus, _event_rx) = EventBus::channel(64);
+    let (event_bus, event_rx) = EventBus::channel(64);
     let flow_runner = Arc::new(HardcodedFlowRunner::new(
         Arc::new(StubInference),
         event_bus.clone(),
     ));
     let session = SessionManager::new(flow_runner, event_bus);
+
+    // Keep the sole consumer alive so the mpsc channel stays open; drain events so publishes never
+    // fail with Closed/Full during normal operation.
+    tokio::spawn(async move {
+        let mut event_rx = event_rx;
+        while let Some(ev) = event_rx.recv().await {
+            debug!(target: "pai_engine::event_bus", ?ev, "domain event");
+        }
+    });
     info!(
         "Booting paiOS engine workspace (session state: {:?})...",
         session.state_machine().state()

--- a/engine/pai-engine/src/main.rs
+++ b/engine/pai-engine/src/main.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use clap::{ArgAction, Parser};
-use pai_core::domain::SessionManager;
+use pai_core::adapters::HardcodedFlowRunner;
+use pai_core::domain::{EventBus, SessionManager};
+use pai_core::ports::{InferenceError, InferencePort};
 use std::path::PathBuf;
+use std::sync::Arc;
 use tracing::{error, info};
 use tracing_subscriber::FmtSubscriber;
 
@@ -34,8 +37,22 @@ async fn main() -> Result<()> {
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    // 3. Bootstrap engine — core session orchestration (adapters wire in later)
-    let session = SessionManager::new();
+    // 3. Bootstrap engine — core session orchestration (stub inference until real adapters wire in)
+    #[derive(Debug)]
+    struct StubInference;
+
+    impl InferencePort for StubInference {
+        fn complete(&self, prompt: &str) -> Result<String, InferenceError> {
+            Ok(format!("[stub] {prompt}"))
+        }
+    }
+
+    let (event_bus, _event_rx) = EventBus::channel(64);
+    let flow_runner = Arc::new(HardcodedFlowRunner::new(
+        Arc::new(StubInference),
+        event_bus.clone(),
+    ));
+    let session = SessionManager::new(flow_runner, event_bus);
     info!(
         "Booting paiOS engine workspace (session state: {:?})...",
         session.state_machine().state()


### PR DESCRIPTION
## Summary
- Add `EventBus` (bounded `tokio::sync::mpsc`) and `DomainEvent` for inference requested/completed.
- Define `FlowRunner`, `InferencePort`, `FlowType::InferenceEcho`, `SessionContext`, and `FlowResult`.
- Implement `HardcodedFlowRunner` adapter (request → inference → response) with event publishing.
- Extend `SessionManager` with injected `FlowRunner` + `EventBus` and `handle_flow_request` (state transitions + flow execution).
- Wire stub `InferencePort` in `pai-engine` main.

## Test plan
- `cargo test -p pai-core`
- `cargo clippy -p pai-core --all-targets -- -D warnings`
- `cargo build -p pai-engine`

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added event-driven architecture with EventBus tracking inference requests and completions
  * Implemented flow execution framework supporting structured inference operations
  * Enhanced SessionManager with flow request handling and improved state management
  * Introduced port-based abstractions enabling flexible inference provider integration
  * Added event publishing throughout inference lifecycle for better operation visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->