### PR TITLE
fix(ci): privileged Docker for debos OS image build

### DIFF
--- a/.github/workflows/os-build.yml
+++ b/.github/workflows/os-build.yml
@@ -31,7 +31,6 @@ jobs:
           docker run --rm \
             --privileged \
             -v "${{ github.workspace }}:/build" -w /build \
-            --cap-add SYS_ADMIN \
             godebos/debos \
             --disable-fakemachine -t machine:radxa-rock5c os/image.yaml
 

--- a/.github/workflows/os-build.yml
+++ b/.github/workflows/os-build.yml
@@ -23,9 +23,13 @@ jobs:
       - name: Build pai-engine .deb
         run: bash os/packaging/build-deb.sh
 
+      # --privileged: debos with --disable-fakemachine needs loop devices (/dev/loop-control).
+      # Default docker run does not expose them; GitHub-hosted runners otherwise fail with
+      # "could not open /dev/loop-control".
       - name: Build image with debos
         run: |
           docker run --rm \
+            --privileged \
             -v "${{ github.workspace }}:/build" -w /build \
             --cap-add SYS_ADMIN \
             godebos/debos \

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "foldhash"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

[CI run 24064554874](https://github.com/aurintex/pai-os/actions/runs/24064554874) failed on **Build OS image** during `debos` with `--disable-fakemachine`. Logs showed:

`could not open /dev/loop-control: no such file or directory`

With fakemachine disabled, debos runs on the host namespace inside the container and needs loop devices to build the image. The default `docker run` does not expose `/dev/loop-control`.

## Fix

Add `--privileged` to the `docker run` that invokes `godebos/debos`, which is the usual approach for debos/image builds in CI when fakemachine is not available.

## Verification

Workflow YAML validated; full OS image build is not reproduced locally (Docker-in-Docker differs from GitHub Actions).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aurintex.slack.com/archives/C0AS4PJLWSU/p1775560778854819?thread_ts=1775560778.854819&cid=C0AS4PJLWSU)

<div><a href="https://cursor.com/agents/bc-9bad3199-128a-59ef-a5bd-71b9268a3d9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bad3199-128a-59ef-a5bd-71b9268a3d9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build workflow for image generation: the build container now runs in full privileged mode instead of a narrowly scoped capability grant, preserving existing mount, working directory, and image parameters. This change adjusts how the build environment is launched without altering public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->